### PR TITLE
Patch pour bouton Précédent novalidate

### DIFF
--- a/templates/inscription/formulaire_inscription.html
+++ b/templates/inscription/formulaire_inscription.html
@@ -37,7 +37,7 @@
                 {{ wizard.form.errors }}
                 {% endcomment %}
                 {% if wizard.steps.prev %}
-                    <button class="btn btn-outline-danger" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}"><span class="fa fa-arrow-left" aria-hidden="true"></span> Précédent</button>
+                    <button class="btn btn-outline-danger" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" formnovalidate><span class="fa fa-arrow-left" aria-hidden="true"></span> Précédent</button>
                 {% endif %}
                 <button class="btn btn-outline-success float-end" name="wizard_goto_step" type="submit" > Suivant <span class="fa fa-arrow-right" aria-hidden="true"></span></button>
                 </form>


### PR DESCRIPTION
Patch pour ne pas valider le formulaire quand on clique sur le bouton "Précédent"
Il suffit d'ajouter l'attribut **formnovalidate** au bouton en question dans le template du formulaire (voir le commit).
Plus d'info ici : https://www.w3schools.com/tags/att_input_formnovalidate.asp